### PR TITLE
Add graph minimization to demographic tabs

### DIFF
--- a/children_tab.py
+++ b/children_tab.py
@@ -55,32 +55,34 @@ def render_children_tab(df, jamati_member_df, education_df, finance_df, physical
         col1, col2 = st.columns(2)
         
         with col1:
-            age_counts = children_df['age'].value_counts().sort_index()
-            age_fig = px.bar(
-                x=age_counts.index,
-                y=age_counts.values,
-                title='Children Age Distribution',
-                labels={'x': 'Age', 'y': 'Number of Children'},
-                color=age_counts.values,
-                color_continuous_scale='Blues'
-            )
-            age_fig.update_layout(showlegend=False, coloraxis_showscale=False)
-            st.plotly_chart(age_fig, use_container_width=True)
+            with st.expander("📈 Children Age Distribution", expanded=True):
+                age_counts = children_df['age'].value_counts().sort_index()
+                age_fig = px.bar(
+                    x=age_counts.index,
+                    y=age_counts.values,
+                    title='Children Age Distribution',
+                    labels={'x': 'Age', 'y': 'Number of Children'},
+                    color=age_counts.values,
+                    color_continuous_scale='Blues'
+                )
+                age_fig.update_layout(showlegend=False, coloraxis_showscale=False)
+                st.plotly_chart(age_fig, use_container_width=True)
         
         with col2:
-            children_origin_counts = children_df['countryoforigin'].dropna()
-            children_origin_counts = children_origin_counts[children_origin_counts != ""].value_counts()
-            
-            if not children_origin_counts.empty:
-                origin_fig = px.pie(
-                    children_origin_counts, 
-                    values=children_origin_counts.values, 
-                    names=children_origin_counts.index, 
-                    title='Children Country of Origin Distribution'
-                )
-                st.plotly_chart(origin_fig, use_container_width=True)
-            else:
-                st.write("No country of origin data available for children.")
+            with st.expander("🌍 Children Country of Origin Distribution", expanded=True):
+                children_origin_counts = children_df['countryoforigin'].dropna()
+                children_origin_counts = children_origin_counts[children_origin_counts != ""].value_counts()
+                
+                if not children_origin_counts.empty:
+                    origin_fig = px.pie(
+                        children_origin_counts, 
+                        values=children_origin_counts.values, 
+                        names=children_origin_counts.index, 
+                        title='Children Country of Origin Distribution'
+                    )
+                    st.plotly_chart(origin_fig, use_container_width=True)
+                else:
+                    st.write("No country of origin data available for children.")
         
         # Education data for children
         st.markdown("## 📚 Children's Education Status")
@@ -118,21 +120,22 @@ def render_children_tab(df, jamati_member_df, education_df, finance_df, physical
                     st.dataframe(edu_summary_df, hide_index=True)
                 
                 with col2:
-                    # Academic performance distribution
-                    perf_col = 'academicperformance' if 'academicperformance' in children_edu_merged.columns else 'AcademicPerformance'
-                    if perf_col in children_edu_merged.columns:
-                        perf_counts = children_edu_merged[perf_col].dropna().value_counts()
-                        if not perf_counts.empty:
-                            perf_fig = px.bar(
-                                x=perf_counts.index,
-                                y=perf_counts.values,
-                                title='Academic Performance Distribution',
-                                labels={'x': 'Performance Level', 'y': 'Number of Children'},
-                                color=perf_counts.values,
-                                color_continuous_scale='Viridis'
-                            )
-                            perf_fig.update_layout(showlegend=False, coloraxis_showscale=False)
-                            st.plotly_chart(perf_fig, use_container_width=True)
+                    with st.expander("🏆 Academic Performance Distribution", expanded=True):
+                        # Academic performance distribution
+                        perf_col = 'academicperformance' if 'academicperformance' in children_edu_merged.columns else 'AcademicPerformance'
+                        if perf_col in children_edu_merged.columns:
+                            perf_counts = children_edu_merged[perf_col].dropna().value_counts()
+                            if not perf_counts.empty:
+                                perf_fig = px.bar(
+                                    x=perf_counts.index,
+                                    y=perf_counts.values,
+                                    title='Academic Performance Distribution',
+                                    labels={'x': 'Performance Level', 'y': 'Number of Children'},
+                                    color=perf_counts.values,
+                                    color_continuous_scale='Viridis'
+                                )
+                                perf_fig.update_layout(showlegend=False, coloraxis_showscale=False)
+                                st.plotly_chart(perf_fig, use_container_width=True)
         else:
             st.info("No education data available for children in the system.")
         

--- a/demographics_tab.py
+++ b/demographics_tab.py
@@ -9,64 +9,67 @@ def render_demographics_tab(jamati_member_df):
     col1, col2 = st.columns(2)
 
     with col1:
-        origin_counts = jamati_member_df['countryoforigin'].dropna()
-        origin_counts = origin_counts[origin_counts != ""].value_counts()
+        with st.expander("🌍 Country of Origin Distribution", expanded=True):
+            origin_counts = jamati_member_df['countryoforigin'].dropna()
+            origin_counts = origin_counts[origin_counts != ""].value_counts()
 
-        fig = px.pie(origin_counts, values=origin_counts.values, names=origin_counts.index, title='Country of Origin Distribution')
-        st.plotly_chart(fig, use_container_width=True)
+            fig = px.pie(origin_counts, values=origin_counts.values, names=origin_counts.index, title='Country of Origin Distribution')
+            st.plotly_chart(fig, use_container_width=True)
     
     with col2:
-        # Calculate age from yearofbirth
-        if 'yearofbirth' in jamati_member_df.columns:
-            # Filter out rows with NaN or empty yearofbirth
-            valid_years_df = jamati_member_df.dropna(subset=['yearofbirth'])
-            valid_years_df = valid_years_df[valid_years_df['yearofbirth'] != ""]
-            
-            # Filter out yearofbirth values greater than 2024 or equal to 0
-            valid_years_df = valid_years_df[(valid_years_df['yearofbirth'] <= 2024) & (valid_years_df['yearofbirth'] > 1800)]
+        with st.expander("📊 Age Distribution", expanded=True):
+            # Calculate age from yearofbirth
+            if 'yearofbirth' in jamati_member_df.columns:
+                # Filter out rows with NaN or empty yearofbirth
+                valid_years_df = jamati_member_df.dropna(subset=['yearofbirth'])
+                valid_years_df = valid_years_df[valid_years_df['yearofbirth'] != ""]
+                
+                # Filter out yearofbirth values greater than 2024 or equal to 0
+                valid_years_df = valid_years_df[(valid_years_df['yearofbirth'] <= 2024) & (valid_years_df['yearofbirth'] > 1800)]
 
-            current_year = pd.Timestamp.now().year
-            valid_years_df['age'] = current_year - valid_years_df['yearofbirth']
-            
-            # Create a histogram of ages with visual distinction
-            age_histogram = px.histogram(valid_years_df, x='age', nbins=20, title='Age Distribution', opacity=0.8)
-            # Update layout to add spacing between bars
-            age_histogram.update_traces(marker_line_width=1, marker_line_color="white")
-            st.plotly_chart(age_histogram, use_container_width=True)
-        else:
-            st.write("Year of birth data is not available in the dataset.")
+                current_year = pd.Timestamp.now().year
+                valid_years_df['age'] = current_year - valid_years_df['yearofbirth']
+                
+                # Create a histogram of ages with visual distinction
+                age_histogram = px.histogram(valid_years_df, x='age', nbins=20, title='Age Distribution', opacity=0.8)
+                # Update layout to add spacing between bars
+                age_histogram.update_traces(marker_line_width=1, marker_line_color="white")
+                st.plotly_chart(age_histogram, use_container_width=True)
+            else:
+                st.write("Year of birth data is not available in the dataset.")
 
     # Add education level visualization
-    if 'educationlevel' in jamati_member_df.columns:
-        # Filter out null values and empty strings, then get value counts
-        education_counts = jamati_member_df['educationlevel'].dropna()
-        education_counts = education_counts[education_counts != ""].value_counts()
-        
-        if not education_counts.empty:  # Only create visualization if we have data
-            # Create a bar chart for education levels
-            education_fig = px.bar(
-                x=education_counts.index,
-                y=education_counts.values,
-                title='Education Level Distribution',
-                labels={'x': 'Education Level', 'y': 'Number of Members'},
-                color=education_counts.values,
-                color_continuous_scale='Viridis'
-            )
+    with st.expander("🎓 Education Level Distribution", expanded=True):
+        if 'educationlevel' in jamati_member_df.columns:
+            # Filter out null values and empty strings, then get value counts
+            education_counts = jamati_member_df['educationlevel'].dropna()
+            education_counts = education_counts[education_counts != ""].value_counts()
             
-            # Update layout for better visualization
-            education_fig.update_layout(
-                showlegend=False,
-                xaxis_tickangle=45,
-                margin=dict(b=100),  # Add bottom margin for rotated labels
-                coloraxis_showscale=False  # Hide the color scale
-            )
-            
-            # Display the chart
-            st.plotly_chart(education_fig, use_container_width=True)
+            if not education_counts.empty:  # Only create visualization if we have data
+                # Create a bar chart for education levels
+                education_fig = px.bar(
+                    x=education_counts.index,
+                    y=education_counts.values,
+                    title='Education Level Distribution',
+                    labels={'x': 'Education Level', 'y': 'Number of Members'},
+                    color=education_counts.values,
+                    color_continuous_scale='Viridis'
+                )
+                
+                # Update layout for better visualization
+                education_fig.update_layout(
+                    showlegend=False,
+                    xaxis_tickangle=45,
+                    margin=dict(b=100),  # Add bottom margin for rotated labels
+                    coloraxis_showscale=False  # Hide the color scale
+                )
+                
+                # Display the chart
+                st.plotly_chart(education_fig, use_container_width=True)
+            else:
+                st.write("No valid education level data available.")
         else:
-            st.write("No valid education level data available.")
-    else:
-        st.write("Education level data is not available in the dataset.")
+            st.write("Education level data is not available in the dataset.")
     
     # Display the dataframe below the charts
     st.subheader("Jamati Member Data")


### PR DESCRIPTION
Add collapsible containers to all graphs on the Jamati Demographics and Children's Demographics tabs to allow users to focus on table data.

---
<a href="https://cursor.com/background-agent?bcId=bc-382ccf6d-6a64-4f72-9053-a75b62b11dab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-382ccf6d-6a64-4f72-9053-a75b62b11dab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

